### PR TITLE
Moved qb-customs code to its resource

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -202,8 +202,8 @@ local function setRadialState(bool, sendMessage, delay)
     
     local items
     if bool then
-        items = deepcopy(Config.MenuItems)
         TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
+        items = deepcopy(Config.MenuItems)
     else
         TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -194,6 +194,7 @@ local function selectOption(t, t2)
 end
 
 local function setRadialState(bool, sendMessage, delay)
+    -- Menuitems have to be added only once
     if not radialMenuSetup then
         setupSubItems()
         radialMenuSetup = true

--- a/client/main.lua
+++ b/client/main.lua
@@ -203,6 +203,9 @@ local function setRadialState(bool, sendMessage, delay)
     local items
     if bool then
         items = deepcopy(Config.MenuItems)
+        TriggerEvent('qb-radialmenu:client:onRadialmenuOpen')
+    else
+        TriggerEvent('qb-radialmenu:client:onRadialmenuClose')
     end
     SetNuiFocus(bool, bool)
     if sendMessage then


### PR DESCRIPTION
Counterpart to [this qb-customs PR](https://github.com/ItsANoBrainer/qb-customs/pull/2).  Allows adding and removing menu items by export['qb-radialmenu']:AddOption and export['qb-radialmenu']:RemoveOption which allows moving the qb-customs code to its resource, thus separating the "responsibilities" of both resources and avoiding unnecessary dependencies.