### PR TITLE
Allow police and ems to use the radialmenu when downed

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -159,7 +159,7 @@ local function SetupRadialMenu()
                 [1] = {
                     id = 'emergencybutton2',
                     title = Lang:t("options.emergency_button"),
-                    icon = '#general',
+                    icon = 'exclamation-circle',
                     type = 'client',
                     event = 'police:client:SendPoliceEmergencyAlert',
                     shouldClose = true,


### PR DESCRIPTION
1. Allows police and ems to use the radialmenu when downed to trigger the emergency button.
2. Triggering the onRadialmenuOpen event before the radial menu is setup which allows for options to be added before the radial menu is shown, preventing the player from having to press F1 twice to see the newly added option.